### PR TITLE
Reference the k325 branch of the kintex-chatter prjxray-db repository.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/YosysHQ/nextpnr-tests
 [submodule "xilinx/external/prjxray-db"]
 	path = xilinx/external/prjxray-db
-	url = https://github.com/SymbiFlow/prjxray-db
+	url = https://github.com/kintex-chatter/prjxray-db
 [submodule "xilinx/external/nextpnr-xilinx-meta"]
 	path = xilinx/external/nextpnr-xilinx-meta
 	url = https://github.com/gatecat/nextpnr-xilinx-meta


### PR DESCRIPTION
This removes the need to manually replace this directory in the build.

It allows the removal of steps 11 through 14 of the main README.md procedure.